### PR TITLE
fix: cache issue in importmap path mappings in sandbox.html

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -15,7 +15,7 @@ run = 'npm install'
 [[task]]
 name = 'serve'
 deps = ['build']
-run = 'npx http-server -o /sandbox.html'
+run = 'npx http-server -c-1 -o /sandbox.html'
 
 [[task]]
 name = 'build'

--- a/sandbox.html
+++ b/sandbox.html
@@ -26,7 +26,7 @@
     "./src/toast.js": "./src/toast.js?1",
     "./src/url-shim.js": "./src/url-shim.js?1",
     "./src/utils.js": "./src/utils.js?1",
-    "mapapp": "./src/mapapp.js"
+    "mapapp": "./src/mapapp.js?1"
   },
   "scopes": {
     "./": {
@@ -128,7 +128,6 @@
     "./src/dependencies.js?1": "sha384-DG/eERQfqEzYFHucrSorl644ZVIRPSj37G/7qmpwLFeejXft1Tx6Gru1rero2bWS",
     "./src/dragdrop.js?1": "sha384-kGESzNFIQEHcgHxRopP/wn0rwIpD3In6/x7MMOc9sPGB6PXxobAjzqdrCwEX4nyK",
     "./src/help.js?1": "sha384-yrnrCIA+FRZadLb+0SteCSr/m9puRhq94E2sG97ckVPfcqGdLf2usVlciueg3ynG",
-    "./src/mapapp.js": "sha384-+lN8EMt2pAJ2kBXk7ssae7Q4mTE9IZSRnAue57XcRuUksqptA52z/nr8cQBCn043",
     "./src/mapapp.js?1": "sha384-+lN8EMt2pAJ2kBXk7ssae7Q4mTE9IZSRnAue57XcRuUksqptA52z/nr8cQBCn043",
     "./src/popup.js?1": "sha384-Ll4Kt2YDaGYi/X02OGxM9+J+I942EDdOYxaVx43nFt2wfSHpnnWiHwZ43RkbCMsA",
     "./src/progress.js?1": "sha384-5fPEG5cu2BN1BcBbsGEybmm2IQ/wwZhl0cgGMyW//6Fj7e78dfZKkNEvWLrP6T55",
@@ -275,7 +274,6 @@
 <link rel="modulepreload" href="src/dependencies.js?1" />
 <link rel="modulepreload" href="src/dragdrop.js?1" />
 <link rel="modulepreload" href="src/help.js?1" />
-<link rel="modulepreload" href="src/mapapp.js" />
 <link rel="modulepreload" href="src/mapapp.js?1" />
 <link rel="modulepreload" href="src/popup.js?1" />
 <link rel="modulepreload" href="src/progress.js?1" />


### PR DESCRIPTION
Turns out, while updating the map. I ended up with two `maapp` mappings. And it started to load generator multiple times. Which is causing the `this._install` to return `void` when there was a install in progress. This is fixed now, can be released to production.

fixes #47 