### PR TITLE
Improved wording for the JSPM Generator credits

### DIFF
--- a/src/mapapp.js
+++ b/src/mapapp.js
@@ -22,7 +22,7 @@ const htmlTemplate = ({ editUrl, boilerplate, title, scripts, map, system, prelo
     mapType = 'importmap';
   }
   const injection = `${
-    map ? `\n<!--\n  JSPM Generator Import Map\n  Edit URL: ${editUrl}\n-->\n <script type="${mapType}">${nl}${JSON.stringify(map, null, nl ? 2 : 0)}${nl}</script>` : ''
+    map ? `\n<!--\n  Import map generated with JSPM Generator\n  Edit here: ${editUrl}\n-->\n<script type="${mapType}">${nl}${JSON.stringify(map, null, nl ? 2 : 0)}${nl}</script>` : ''
   }${nl}${
     scripts ? '\n' + scripts.filter(({ hidden }) => !hidden || boilerplate && !minify).map(({ url, integrity, hidden, async, module, comment, crossorigin }) =>
       `${comment && !minify ? `<!--${comment.indexOf('\n') !== -1 ? '\n  ' : ' '}${comment.split('\n').join('\n  ')}${comment.indexOf('\n') !== -1 ? '\n' : ' '}-->\n` : ''}${hidden ? '<!-- ' : ''}<script ${async ? 'async ' : ''}${module ? 'type="module" ' : ''}src="${url}"${useIntegrity && integrity ? ` integrity="${integrity}"` : ''}${crossorigin ? ' crossorigin="anonymous"' : ''}></script>${hidden ? ' -->' : ''}`


### PR DESCRIPTION
This wording makes it a little more clear that a tool was used to generate the import map (especially for people who are brand new to import maps), making it more of a call to action.

I also removed an extra space that was triggering my OCD.

Before:

<img width="831" alt="Screenshot 2025-02-01 at 11 52 59 AM" src="https://github.com/user-attachments/assets/e38a04dc-9348-4b46-84bc-129630eb3205" />

After:

<img width="755" alt="Screenshot 2025-02-01 at 11 54 54 AM" src="https://github.com/user-attachments/assets/4cf4375a-623c-4c0f-a8aa-cff4a5a1e8ab" />

